### PR TITLE
Add defaultLanguage configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A Visual Studio Code extension for [cht.sh](https://cht.sh/).
 * `verbose`: add comments around code snippets.
 * `baseUrl`: base url of the cheat server ([see cheat.sh documentation](https://github.com/chubin/cheat.sh/issues/98#issuecomment-412472258))
 * `http.proxy`: VS Code proxy setting. If set, requests made by vscode-snippet will be sent through provided proxy ([see Visual Studio Code network settings](https://code.visualstudio.com/docs/setup/network))
+* `defaultLanguage`: Programming language name in lower case to use as default language when there is no open editor window.
 
 
 

--- a/package.json
+++ b/package.json
@@ -97,6 +97,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Also show explanations for code snippets."
+                },
+                "snippet.defaultLanguage": {
+                    "type": "string",
+                    "default": null,
+                    "description": "Programming language name in lower case to use as default language when there is no open editor window."
                 }
             }
         },


### PR DESCRIPTION
As discussed in #19 this PR creates a new configuration option to allow users set a default language to use whenever the find command is used and there is no open editor window.