### PR TITLE
Refactoring: split up codebase into separate files and make code more idiomatic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,15 @@
             "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
             "dev": true
         },
+        "axios": {
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+            "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+            "requires": {
+                "follow-redirects": "1.5.10",
+                "is-buffer": "^2.0.2"
+            }
+        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -240,6 +249,14 @@
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
             "dev": true
         },
+        "follow-redirects": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+            "requires": {
+                "debug": "=3.1.0"
+            }
+        },
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -370,6 +387,11 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
             "dev": true
+        },
+        "is-buffer": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+            "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
         },
         "is-typedarray": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
             "properties": {
                 "snippet.baseUrl": {
                     "type": "string",
-                    "default": "cht.sh",
+                    "default": "https://cht.sh",
                     "description": "Base URL of the cheat sheet server"
                 },
                 "snippet.openInNewEditor": {
@@ -142,7 +142,8 @@
         "test": "npm run compile && node ./node_modules/vscode/bin/test"
     },
     "dependencies": {
-        "http-proxy-agent": "^2.1.0",
-        "event-stream": "3.3.4"
+        "axios": "^0.19.0",
+        "event-stream": "3.3.4",
+        "http-proxy-agent": "^2.1.0"
     }
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,7 @@
+'use strict'
+
+import * as vscode from 'vscode'
+
+export const cache = {
+    state: <vscode.Memento>null
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,14 +1,11 @@
 'use strict'
-import * as http from 'http'
+
 import * as vscode from 'vscode'
-import { HttpProxyAgent } from 'http-proxy-agent'
+import { query, asyncRequest } from './query'
+import { cache } from './cache'
 
 let loadingStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left)
 loadingStatus.text = 'Loading Snippet ...'
-
-const cache = {
-    state: <vscode.Memento>null
-}
 
 // Query string that was executed (not escaped)
 var currQuery = null
@@ -40,19 +37,13 @@ export function activate(ctx: vscode.ExtensionContext) {
         'snippet.toggleComments', toggleComments))
 }
 
-function find() {
-    let configuration = vscode.workspace.getConfiguration('snippet')
-    let openInNewEditor: boolean = configuration["openInNewEditor"]
-    query(openInNewEditor)
-}
-
-function query(openInNewEditor: boolean) {
+function getLanguage(): string {
     let language: string = null
     let editor = vscode.window.activeTextEditor
     let configuration = vscode.workspace.getConfiguration('snippet')
     if (!editor) {
         let defaultLanguage: string = configuration['defaultLanguage']
-        if (!defaultLanguage || /^\s+$/i.test(defaultLanguage) || !openInNewEditor) {
+        if (!defaultLanguage || /^\s+$/i.test(defaultLanguage) || !configuration.openInNewEditor) {
             vscode.window.showErrorMessage('There is no open editor window');
             return
         }
@@ -60,55 +51,37 @@ function query(openInNewEditor: boolean) {
     } else {
         language = editor.document.languageId
     }
+    return language
+}
 
-    let tree = cache.state.get(`snippet_${language}`, {})
-    let suggestions = []
-    for (var key in tree) {
-        suggestions.push(tree[key])
-    }
-    suggestions.sort()
 
-    let suggestionsQuickItems: Array<vscode.QuickPickItem> = []
-    let tempQuickItem: vscode.QuickPickItem = null
-    for (var key in suggestions) {
-        tempQuickItem = { description: '', label: suggestions[key] }
-        suggestionsQuickItems.push(tempQuickItem)
-    }
 
-    let window = vscode.window
-    const quickPick = (<any>window).createQuickPick()
-    quickPick.items = suggestionsQuickItems
-    quickPick.onDidChangeValue(() => {
-        quickPick.activeItems = []
-    })
-
+async function find() {
+    let configuration = vscode.workspace.getConfiguration('snippet')
     let verbose: boolean = configuration["verbose"]
-
-    quickPick.onDidAccept(() => {
-        if (quickPick.activeItems.length) {
-            asyncRequest(quickPick.activeItems[0]['label'], 0, verbose, language, function (data) {
-                insertText(data, language, openInNewEditor)
-            })
-        } else {
-            asyncRequest(quickPick.value, 0, verbose, language, function (data) {
-                insertText(data, language, openInNewEditor)
-            })
-        }
-        quickPick.hide()
-        quickPick.dispose()
-    })
-    quickPick.show()
+    let openInNewEditor: boolean = configuration["openInNewEditor"]
+    let language = getLanguage()
+    let response = await query(language, verbose)
+    insertText(response.data, language, openInNewEditor)
 }
 
-function findInplace() {
-    query(false)
+async function findInplace() {
+    let configuration = vscode.workspace.getConfiguration('snippet')
+    let verbose: boolean = configuration["verbose"]
+    let language = getLanguage()
+    let response = await query(language, verbose)
+    insertText(response.data, language, false)
 }
 
-function findInNewEditor() {
-    query(true)
+async function findInNewEditor() {
+    let configuration = vscode.workspace.getConfiguration('snippet')
+    let verbose: boolean = configuration["verbose"]
+    let language = getLanguage()
+    let response = await query(language, verbose)
+    insertText(response.data, language, true)
 }
 
-function showNextAnswer() {
+async function showNextAnswer() {
     let editor = vscode.window.activeTextEditor
     if (!editor) {
         vscode.window.showErrorMessage('There is no open editor window');
@@ -123,12 +96,11 @@ function showNextAnswer() {
     currNum += 1;
 
     let verbose: boolean = configuration["verbose"]
-    asyncRequest(currQuery, currNum, verbose, language, function (data) {
-        insertText(data, language, openInNewEditor)
-    })
+    let response = await asyncRequest(currQuery, currNum, verbose, language)
+    insertText(response.data, language, openInNewEditor)
 }
 
-function showPreviousAnswer() {
+async function showPreviousAnswer() {
     let editor = vscode.window.activeTextEditor
     if (!editor) {
         vscode.window.showErrorMessage('There is no open editor window');
@@ -145,12 +117,11 @@ function showPreviousAnswer() {
     }
     let verbose: boolean = configuration["verbose"]
 
-    asyncRequest(currQuery, currNum, verbose, language, function (data) {
-        insertText(data, language, openInNewEditor)
-    })
+    let response = await asyncRequest(currQuery, currNum, verbose, language)
+    insertText(response.data, language, openInNewEditor)
 }
 
-function toggleComments() {
+async function toggleComments() {
     let editor = vscode.window.activeTextEditor
     if (!editor) {
         vscode.window.showErrorMessage('There is no open editor window');
@@ -163,12 +134,11 @@ function toggleComments() {
     let openInNewEditor: boolean = configuration["openInNewEditor"]
     verboseState = !verboseState
 
-    asyncRequest(currQuery, currNum, verboseState, language, function (data) {
-        insertText(data, language, openInNewEditor)
-    })
+    let response = await asyncRequest(currQuery, currNum, verboseState, language)
+    insertText(response.data, language, openInNewEditor)
 }
 
-function findSelectedText() {
+async function findSelectedText() {
     let editor = vscode.window.activeTextEditor
     if (!editor) {
         vscode.window.showErrorMessage('There is no open editor window');
@@ -184,89 +154,8 @@ function findSelectedText() {
     let openInNewEditor: boolean = configuration["openInNewEditor"]
     let verbose: boolean = configuration["verbose"]
 
-    asyncRequest(query, 0, verbose, language, function (data) {
-        insertText(data, language, openInNewEditor)
-    })
-}
-
-
-var requestCache = new Object()
-function asyncRequest(queryRaw: string, num: number, verbose: boolean, language: string, callback: (data: string) => void) {
-
-    currQuery = queryRaw
-    currNum = num
-
-    loadingStatus.show()
-
-    try {
-        let query = encodeURI(queryRaw.replace(/ /g, '+'))
-    } catch (TypeError) {
-        loadingStatus.hide()
-        return
-    }
-
-    let query = encodeURI(queryRaw.replace(/ /g, '+'))
-
-    let configuration = vscode.workspace.getConfiguration('snippet')
-    let params = "QT"
-    if (verbose) {
-        params = "qT"
-    }
-
-    let baseUrl: String = configuration["baseUrl"]
-
-    let path = `/vscode:${language}/${query}/${num}?${params}&style=bw`;
-
-    let data = requestCache[path]
-    if (data) {
-        loadingStatus.hide()
-        callback(data)
-        return
-    }
-
-    console.log(`asyncRequest: ${query}`)
-
-    let opts = {
-        'host': baseUrl,
-        'path': path,
-        // Fake user agent to get plain-text output.
-        // See https://github.com/chubin/cheat.sh/blob/1e21d96d065b6cce7d198c1a3edba89081c78a0b/bin/srv.py#L47
-        'headers': {
-            'User-Agent': 'curl/7.43.0'
-        },
-    }
-
-    // Apply proxy setting if provided
-    let httpConfiguration = vscode.workspace.getConfiguration('http')
-    let proxy = httpConfiguration['proxy']
-
-    if (proxy !== '') {
-        let agent = new HttpProxyAgent(proxy)
-        opts['agent'] = agent
-    }
-
-    http.get(opts, function (message) {
-        let data = ""
-
-        message.on("data", function (chunk) {
-            data += chunk
-        })
-
-        message.on("end", function () {
-            requestCache[path] = data
-            let cacheData = cache.state.get(`snippet_${language}`)
-            if (query !== undefined && query !== '') {
-                if (!cacheData[queryRaw]) {
-                    cacheData[queryRaw] = queryRaw
-                    cache.state.update(`snippet_${language}`, cacheData)
-                }
-            }
-            loadingStatus.hide()
-            callback(data)
-        })
-    }).on("error", function (err) {
-        vscode.window.showInformationMessage(err.message)
-    })
+    let response = await asyncRequest(query, 0, verbose, language)
+    insertText(response.data, language, openInNewEditor)
 }
 
 function insertText(content: string, language: string, openInNewEditor = true) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,7 +59,8 @@ async function find() {
     let verbose: boolean = configuration["verbose"]
     let openInNewEditor: boolean = configuration["openInNewEditor"]
     let language = getLanguage()
-    let response = await query(language, verbose)
+    currQuery = await query(language, verbose)
+    let response = await asyncRequest(currQuery, 0, verbose, language)
     insertText(response.data, language, openInNewEditor)
 }
 
@@ -67,7 +68,8 @@ async function findInplace() {
     let configuration = vscode.workspace.getConfiguration('snippet')
     let verbose: boolean = configuration["verbose"]
     let language = getLanguage()
-    let response = await query(language, verbose)
+    currQuery = await query(language, verbose)
+    let response = await asyncRequest(currQuery, 0, verbose, language)
     insertText(response.data, language, false)
 }
 
@@ -75,7 +77,8 @@ async function findInNewEditor() {
     let configuration = vscode.workspace.getConfiguration('snippet')
     let verbose: boolean = configuration["verbose"]
     let language = getLanguage()
-    let response = await query(language, verbose)
+    currQuery = await query(language, verbose)
+    let response = await asyncRequest(currQuery, 0, verbose, language)
     insertText(response.data, language, true)
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ function getLanguage(): string {
     let configuration = vscode.workspace.getConfiguration('snippet')
     if (!editor) {
         let defaultLanguage: string = configuration['defaultLanguage']
-        if (!defaultLanguage || /^\s+$/i.test(defaultLanguage) || !configuration.openInNewEditor) {
+        if (!defaultLanguage || !defaultLanguage.trim() || !configuration.openInNewEditor) {
             vscode.window.showErrorMessage('There is no open editor window');
             return
         }
@@ -53,8 +53,6 @@ function getLanguage(): string {
     }
     return language
 }
-
-
 
 async function find() {
     let configuration = vscode.workspace.getConfiguration('snippet')

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,7 @@
 'use strict'
-import * as cp from 'child_process'
 import * as http from 'http'
 import * as vscode from 'vscode'
-import * as HttpProxyAgent from 'http-proxy-agent'
+import { HttpProxyAgent } from 'http-proxy-agent'
 
 let loadingStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left)
 loadingStatus.text = 'Loading Snippet ...'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,11 +56,11 @@ function getLanguage(): string {
 
 async function find() {
     let configuration = vscode.workspace.getConfiguration('snippet')
-    let verbose: boolean = configuration["verbose"]
     let openInNewEditor: boolean = configuration["openInNewEditor"]
     let language = getLanguage()
-    currQuery = await query(language, verbose)
+    currQuery = await query(language)
     loadingStatus.show()
+    let verbose: boolean = configuration["verbose"]
     let response = await asyncRequest(currQuery, 0, verbose, language)
     loadingStatus.hide()
     insertText(response.data, language, openInNewEditor)
@@ -68,10 +68,10 @@ async function find() {
 
 async function findInplace() {
     let configuration = vscode.workspace.getConfiguration('snippet')
-    let verbose: boolean = configuration["verbose"]
     let language = getLanguage()
-    currQuery = await query(language, verbose)
+    currQuery = await query(language)
     loadingStatus.show()
+    let verbose: boolean = configuration["verbose"]
     let response = await asyncRequest(currQuery, 0, verbose, language)
     loadingStatus.hide()
     insertText(response.data, language, false)
@@ -79,10 +79,10 @@ async function findInplace() {
 
 async function findInNewEditor() {
     let configuration = vscode.workspace.getConfiguration('snippet')
-    let verbose: boolean = configuration["verbose"]
     let language = getLanguage()
-    currQuery = await query(language, verbose)
+    currQuery = await query(language)
     loadingStatus.show()
+    let verbose: boolean = configuration["verbose"]
     let response = await asyncRequest(currQuery, 0, verbose, language)
     loadingStatus.hide()
     insertText(response.data, language, true)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,6 +89,10 @@ async function findInNewEditor() {
 }
 
 async function showNextAnswer() {
+    if (!currQuery) {
+        await find()
+        return
+    }
     let editor = vscode.window.activeTextEditor
     if (!editor) {
         vscode.window.showErrorMessage('There is no open editor window');
@@ -110,6 +114,10 @@ async function showNextAnswer() {
 }
 
 async function showPreviousAnswer() {
+    if (!currQuery) {
+        await find()
+        return
+    }
     let editor = vscode.window.activeTextEditor
     if (!editor) {
         vscode.window.showErrorMessage('There is no open editor window');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,7 @@ async function find() {
     let verbose: boolean = configuration["verbose"]
     let response = await asyncRequest(currQuery, 0, verbose, language)
     loadingStatus.hide()
-    insertText(response.data, language, openInNewEditor)
+    showSnippet(response.data, language, openInNewEditor)
 }
 
 async function findInplace() {
@@ -74,7 +74,7 @@ async function findInplace() {
     let verbose: boolean = configuration["verbose"]
     let response = await asyncRequest(currQuery, 0, verbose, language)
     loadingStatus.hide()
-    insertText(response.data, language, false)
+    showSnippet(response.data, language, false)
 }
 
 async function findInNewEditor() {
@@ -85,7 +85,7 @@ async function findInNewEditor() {
     let verbose: boolean = configuration["verbose"]
     let response = await asyncRequest(currQuery, 0, verbose, language)
     loadingStatus.hide()
-    insertText(response.data, language, true)
+    showSnippet(response.data, language, true)
 }
 
 async function showNextAnswer() {
@@ -106,7 +106,7 @@ async function showNextAnswer() {
     loadingStatus.show()
     let response = await asyncRequest(currQuery, currNum, verbose, language)
     loadingStatus.hide()
-    insertText(response.data, language, openInNewEditor)
+    showSnippet(response.data, language, openInNewEditor)
 }
 
 async function showPreviousAnswer() {
@@ -127,7 +127,7 @@ async function showPreviousAnswer() {
     let verbose: boolean = configuration["verbose"]
 
     let response = await asyncRequest(currQuery, currNum, verbose, language)
-    insertText(response.data, language, openInNewEditor)
+    showSnippet(response.data, language, openInNewEditor)
 }
 
 async function toggleComments() {
@@ -144,7 +144,7 @@ async function toggleComments() {
     verboseState = !verboseState
 
     let response = await asyncRequest(currQuery, currNum, verboseState, language)
-    insertText(response.data, language, openInNewEditor)
+    showSnippet(response.data, language, openInNewEditor)
 }
 
 async function findSelectedText() {
@@ -164,10 +164,10 @@ async function findSelectedText() {
     let verbose: boolean = configuration["verbose"]
 
     let response = await asyncRequest(query, 0, verbose, language)
-    insertText(response.data, language, openInNewEditor)
+    showSnippet(response.data, language, openInNewEditor)
 }
 
-function insertText(content: string, language: string, openInNewEditor = true) {
+function showSnippet(content: string, language: string, openInNewEditor = true) {
 
     if (openInNewEditor) {
         vscode.workspace.openTextDocument({ language, content }).then(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,7 +60,9 @@ async function find() {
     let openInNewEditor: boolean = configuration["openInNewEditor"]
     let language = getLanguage()
     currQuery = await query(language, verbose)
+    loadingStatus.show()
     let response = await asyncRequest(currQuery, 0, verbose, language)
+    loadingStatus.hide()
     insertText(response.data, language, openInNewEditor)
 }
 
@@ -69,7 +71,9 @@ async function findInplace() {
     let verbose: boolean = configuration["verbose"]
     let language = getLanguage()
     currQuery = await query(language, verbose)
+    loadingStatus.show()
     let response = await asyncRequest(currQuery, 0, verbose, language)
+    loadingStatus.hide()
     insertText(response.data, language, false)
 }
 
@@ -78,7 +82,9 @@ async function findInNewEditor() {
     let verbose: boolean = configuration["verbose"]
     let language = getLanguage()
     currQuery = await query(language, verbose)
+    loadingStatus.show()
     let response = await asyncRequest(currQuery, 0, verbose, language)
+    loadingStatus.hide()
     insertText(response.data, language, true)
 }
 
@@ -97,7 +103,9 @@ async function showNextAnswer() {
     currNum += 1;
 
     let verbose: boolean = configuration["verbose"]
+    loadingStatus.show()
     let response = await asyncRequest(currQuery, currNum, verbose, language)
+    loadingStatus.hide()
     insertText(response.data, language, openInNewEditor)
 }
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -24,8 +24,7 @@ export async function query(language: string, verbose: boolean): Promise<any> {
     }
 
     let selection = await vscode.window.showQuickPick(suggestionsQuickItems);
-    let req = asyncRequest(selection.label, 0, verbose, language)
-    return req;
+    return selection.label;
 }
 
 export async function asyncRequest(queryRaw: string, num: number, verbose: boolean, language: string): Promise<any> {

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,0 +1,103 @@
+'use strict'
+
+import * as http from 'http'
+import * as vscode from 'vscode'
+import { cache } from './cache'
+import { HttpProxyAgent } from 'http-proxy-agent'
+const axios = require('axios');
+
+var requestCache = new Object()
+
+export async function query(language: string, verbose: boolean): Promise<any> {
+
+    let tree = cache.state.get(`snippet_${language}`, {})
+    let suggestions = []
+    for (var key in tree) {
+        suggestions.push(tree[key])
+    }
+    suggestions.sort()
+
+    let suggestionsQuickItems: Array<vscode.QuickPickItem> = []
+    let tempQuickItem: vscode.QuickPickItem = null
+    for (var key in suggestions) {
+        tempQuickItem = { description: '', label: suggestions[key] }
+        suggestionsQuickItems.push(tempQuickItem)
+    }
+
+    let selection = await vscode.window.showQuickPick(suggestionsQuickItems);
+    let req = asyncRequest(selection.label, 0, verbose, language)
+    return req;
+}
+
+export async function asyncRequest(queryRaw: string, num: number, verbose: boolean, language: string): Promise<any> {
+    // TODO
+    // loadingStatus.show()
+
+    // try {
+    //     let query = encodeURI(queryRaw.replace(/ /g, '+'))
+    // } catch (TypeError) {
+    //     // loadingStatus.hide()
+    //     // TODO: Rethrow exception
+    //     return ""
+    // }
+
+    let query = encodeURI(queryRaw.replace(/ /g, '+'))
+
+    let configuration = vscode.workspace.getConfiguration('snippet')
+    let params = "QT"
+    if (verbose) {
+        params = "qT"
+    }
+
+    let path = `/vscode:${language}/${query}/${num}?${params}&style=bw`;
+    let data = await requestCache[path]
+    if (data) {
+        // loadingStatus.hide()
+        return data;
+    }
+
+    let baseUrl: String = configuration["baseUrl"]
+    let url = baseUrl + path;
+    let opts = {
+        // Fake user agent to get plain-text output.
+        // See https://github.com/chubin/cheat.sh/blob/1e21d96d065b6cce7d198c1a3edba89081c78a0b/bin/srv.py#L47
+        'headers': {
+            'User-Agent': 'curl/7.43.0'
+        },
+    }
+
+    // Apply proxy setting if provided
+    let httpConfiguration = vscode.workspace.getConfiguration('http')
+    let proxy = httpConfiguration['proxy']
+
+    if (proxy !== '') {
+        let agent = new HttpProxyAgent(proxy)
+        opts['agent'] = agent
+    }
+
+    return await axios.get(url, opts)
+
+    // http.get(opts, function (message) {
+    //     let data = ""
+
+    //     message.on("data", function (chunk) {
+    //         data += chunk
+    //     })
+
+    //     message.on("end", function () {
+    //         requestCache[path] = data
+    //         let cacheData = cache.state.get(`snippet_${language}`)
+    //         if (query !== undefined && query !== '') {
+    //             if (!cacheData[queryRaw]) {
+    //                 cacheData[queryRaw] = queryRaw
+    //                 cache.state.update(`snippet_${language}`, cacheData)
+    //             }
+    //         }
+    //         // TODO
+    //         // loadingStatus.hide()
+    //         return data
+    //     })
+    // }).on("error", function (err) {
+    //     vscode.window.showInformationMessage(err.message)
+    // })
+}

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,6 +1,5 @@
 'use strict'
 
-import * as http from 'http'
 import * as vscode from 'vscode'
 import { cache } from './cache'
 import { HttpProxyAgent } from 'http-proxy-agent'

--- a/src/query.ts
+++ b/src/query.ts
@@ -28,17 +28,6 @@ export async function query(language: string, verbose: boolean): Promise<any> {
 }
 
 export async function asyncRequest(queryRaw: string, num: number, verbose: boolean, language: string): Promise<any> {
-    // TODO
-    // loadingStatus.show()
-
-    // try {
-    //     let query = encodeURI(queryRaw.replace(/ /g, '+'))
-    // } catch (TypeError) {
-    //     // loadingStatus.hide()
-    //     // TODO: Rethrow exception
-    //     return ""
-    // }
-
     let query = encodeURI(queryRaw.replace(/ /g, '+'))
 
     let configuration = vscode.workspace.getConfiguration('snippet')
@@ -50,7 +39,6 @@ export async function asyncRequest(queryRaw: string, num: number, verbose: boole
     let path = `/vscode:${language}/${query}/${num}?${params}&style=bw`;
     let data = await requestCache[path]
     if (data) {
-        // loadingStatus.hide()
         return data;
     }
 
@@ -74,28 +62,4 @@ export async function asyncRequest(queryRaw: string, num: number, verbose: boole
     }
 
     return await axios.get(url, opts)
-
-    // http.get(opts, function (message) {
-    //     let data = ""
-
-    //     message.on("data", function (chunk) {
-    //         data += chunk
-    //     })
-
-    //     message.on("end", function () {
-    //         requestCache[path] = data
-    //         let cacheData = cache.state.get(`snippet_${language}`)
-    //         if (query !== undefined && query !== '') {
-    //             if (!cacheData[queryRaw]) {
-    //                 cacheData[queryRaw] = queryRaw
-    //                 cache.state.update(`snippet_${language}`, cacheData)
-    //             }
-    //         }
-    //         // TODO
-    //         // loadingStatus.hide()
-    //         return data
-    //     })
-    // }).on("error", function (err) {
-    //     vscode.window.showInformationMessage(err.message)
-    // })
 }

--- a/src/query.ts
+++ b/src/query.ts
@@ -9,7 +9,6 @@ const axios = require('axios');
 var requestCache = new Object()
 
 export async function query(language: string, verbose: boolean): Promise<any> {
-
     let tree = cache.state.get(`snippet_${language}`, {})
     let suggestions = []
     for (var key in tree) {


### PR DESCRIPTION
Also I fixed a bug where Snippet was throwing an error if "get next answer" or "get previous answer" was executed without `currentQuery`. In this case we trigger a normal search now.