### PR TITLE
Disable the Lint step for dependabot's PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Lint
         uses: mooyoul/tslint-actions@v1.1.1
+        if: github.actor != 'dependabot[bot]'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pattern: "*.ts"


### PR DESCRIPTION
Currently, the pipeline is failing on dependabot's PRs with "Error: Resource not accessible by integration" on the Lint step. That's because the Lint step requires GITHUB_TOKEN, which has [read-only permissions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events) for dependabot. So I believe we could disable the lint step entirely for dependabot-opened PRs.