### PR TITLE
Create a separate pre-release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,9 @@ jobs:
         with:
           name: package
           path: package.vsix
+
   release:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '-pre')
     needs: build
     runs-on: ubuntu-latest
     name: Release
@@ -59,3 +60,25 @@ jobs:
           PUBLISHER_TOKEN: ${{ secrets.PUBLISHER_TOKEN }}
         with:
           args: publish -p $PUBLISHER_TOKEN -i package.vsix
+
+  pre-release:
+    if: endsWith(github.ref, '-pre')
+    needs: build
+    runs-on: ubuntu-latest
+    name: Pre-release
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - run: npm install
+
+      - name: Vscode release plugin
+        uses: JCofman/vscodeaction@master
+        env:
+          PUBLISHER_TOKEN: ${{ secrets.PUBLISHER_TOKEN }}
+        with:
+          args: publish -p $PUBLISHER_TOKEN --pre-release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snippet",
-  "version": "1.0.0-pre",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snippet",
-      "version": "1.0.0-pre",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snippet",
   "displayName": "Snippet",
   "description": "Insert a snippet from cht.sh for Python, JavaScript, Ruby, C#, Go, Rust (and any other language)",
-  "version": "1.0.0-pre",
+  "version": "1.0.0",
   "publisher": "vscode-snippet",
   "engines": {
     "vscode": "^1.74.0"


### PR DESCRIPTION
Looks like vscode doesn't support semver pre-release flags https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions