### PR TITLE
Hotkeys for selecting prev/next answer

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,6 +202,16 @@
         "key": "ctrl+shift+s",
         "mac": "cmd+shift+s",
         "when": "editorHasSelection"
+      },
+      {
+        "key": "c",
+        "command": "snippet.showNextAnswer",
+        "when": "resourceScheme == 'snippet' && editorReadonly"
+      },
+      {
+        "key": "v",
+        "command": "snippet.showPreviousAnswer",
+        "when": "resourceScheme == 'snippet' && editorReadonly"
       }
     ]
   },

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -43,7 +43,7 @@ export async function findWithProvider(
     await vscode.window.showTextDocument(doc, {
       viewColumn: vscode.ViewColumn.Two,
       preview: true,
-      preserveFocus: true,
+      preserveFocus: false,
     });
   } else {
     const snippet = new vscode.SnippetString(doc.getText());


### PR DESCRIPTION
By adapting the `when` expression to only match editors created by this extension,
I was able to add the hotkeys `c` for next and `v` for previous.

This (in combination with enabling focus switch) enables a mouse-less answer selection:

1. Press hotkey for search
2. wait for snippet
3. Press `c` for next answer
4. Press `Ctrl-A`, `Ctrl-C` to copy
5. Press hotkey for closing editor tab (`Ctrl-W` for me)
6. Paste `Ctrl-V`
7. Profit :+1: 

[Screencast from 2023-03-03 19-00-21.webm](https://user-images.githubusercontent.com/2084639/222794075-196f2641-fc82-4570-bcbd-f5d868a38bce.webm)

