### PR TITLE
Add a workflow for publishing an extension to open-vsx.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,17 @@ jobs:
         with:
           name: package
 
-      - name: Vscode release plugin
-        uses: JCofman/vscodeaction@master
-        env:
-          PUBLISHER_TOKEN: ${{ secrets.PUBLISHER_TOKEN }}
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
         with:
-          args: publish -p $PUBLISHER_TOKEN -i package.vsix
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: package.vsix
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.PUBLISHER_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com
+          extensionFile: package.vsix
 
   pre-release:
     if: endsWith(github.ref, '-pre')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snippet",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snippet",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@vscode/vsce": "^2.19.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snippet",
   "displayName": "Snippet",
   "description": "Insert a snippet from cht.sh for Python, JavaScript, Ruby, C#, Go, Rust (and any other language)",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "publisher": "vscode-snippet",
   "engines": {
     "vscode": "^1.74.0"


### PR DESCRIPTION
Closes #351 

I used this github action: https://github.com/HaaLeo/publish-vscode-extension
In order for this to work, an access token named OPEN_VSX_TOKEN should be added to repository secrets (repository settings -> secrets -> actions -> new repository secret). More info: https://github.com/eclipse/openvsx/wiki/Publishing-Extensions.
