### PR TITLE
Fix error: Activating extension 'vscode-snippet.snippet' failed: Cannot read properties of undefined (reading 'languages').

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snippet",
-  "version": "1.0.4",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snippet",
-      "version": "1.0.4",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@vscode/vsce": "^2.19.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snippet",
   "displayName": "Snippet",
   "description": "Insert a snippet from cht.sh for Python, JavaScript, Ruby, C#, Go, Rust (and any other language)",
-  "version": "1.0.4",
+  "version": "1.1.1",
   "publisher": "vscode-snippet",
   "engines": {
     "vscode": "^1.74.0"

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -3,10 +3,17 @@ import * as vscode from "vscode";
 class Languages {
   constructor(private readonly fileExtensions = new Map<string, string[]>()) {
     for (const extension of vscode.extensions.all) {
-      const languages = extension.packageJSON.contributes.languages;
-      if (languages) {
+      const languages = extension?.packageJSON?.contributes?.languages;
+      if (languages && Array.isArray(languages)) {
         for (const lang of languages) {
-          fileExtensions.set(lang.id, lang.extensions);
+          if (
+            lang &&
+            lang.id &&
+            lang.extensions &&
+            Array.isArray(lang.extensions)
+          ) {
+            fileExtensions.set(lang.id, lang.extensions);
+          }
         }
       }
     }


### PR DESCRIPTION
#390
The error happens only when a user has some extension installed that does not have "contributes" field in it's package.json.