### PR TITLE
Add an ability to copy saved snippet to the clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A Visual Studio Code extension for [cht.sh](https://cht.sh/).
   - ${query} - the snippet query (search text)
   - ${index} - the index of the snippet (e.g. 2 for the third answer)
 - `insertWithDoubleClick`: insert snippet with double click.
+- `showCopySuccessNotification`: Whether to show a notification after the snippet is copied to the clipboard.
 
 ## Installation
 
@@ -108,6 +109,12 @@ You can configure a keyboard shortcut. By default this is <kbd>⌘ Command</kbd>
 4. Confirm your choice
 
 ![Preview](https://raw.githubusercontent.com/mre/vscode-snippet/master/contrib/snippets-storage/delete.gif)
+
+### Copying a snippet to the clipboard
+
+1. Open the Snippets section
+2. Right click on the snippet that you want to copy
+3. Select "Copy"
 
 ### Moving a snippet or a folder
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snippet",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snippet",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@vscode/vsce": "^2.21.0",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,11 @@
         "category": "Snippet"
       },
       {
+        "title": "Find and copy",
+        "command": "snippet.findAndCopy",
+        "category": "Snippet"
+      },
+      {
         "title": "New Folder",
         "command": "snippet.createFolder",
         "category": "Snippet",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snippet",
   "displayName": "Snippet",
   "description": "Insert a snippet from cht.sh for Python, JavaScript, Ruby, C#, Go, Rust (and any other language)",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "publisher": "vscode-snippet",
   "engines": {
     "vscode": "^1.74.0"
@@ -106,6 +106,11 @@
         "category": "Snippet"
       },
       {
+        "title": "Copy",
+        "command": "snippet.copySnippet",
+        "category": "Snippet"
+      },
+      {
         "title": "New Folder",
         "command": "snippet.createFolder",
         "category": "Snippet",
@@ -147,6 +152,11 @@
           "type": "boolean",
           "default": false,
           "description": "Insert snippet with double click."
+        },
+        "snippet.showCopySuccessNotification": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to show a notification after the snippet is copied to the clipboard."
         }
       }
     },
@@ -165,14 +175,19 @@
           "group": "snippet.viewItemContext.baseGroup@1"
         },
         {
+          "command": "snippet.copySnippet",
+          "when": "view == snippetsView && viewItem == snippet",
+          "group": "snippet.viewItemContext.baseGroup@2"
+        },
+        {
           "command": "snippet.renameSnippet",
           "when": "view == snippetsView",
-          "group": "snippet.viewItemContext.baseGroup@2"
+          "group": "snippet.viewItemContext.baseGroup@3"
         },
         {
           "command": "snippet.deleteSnippet",
           "when": "view == snippetsView",
-          "group": "snippet.viewItemContext.baseGroup@3"
+          "group": "snippet.viewItemContext.baseGroup@4"
         }
       ],
       "editor/context": [

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -1,0 +1,32 @@
+import * as vscode from "vscode";
+import { getConfig } from "./config";
+
+export async function copySnippet(content: string): Promise<void> {
+  try {
+    await vscode.env.clipboard.writeText(content);
+
+    if (getConfig("showCopySuccessNotification")) {
+      await showNotification();
+    }
+  } catch {
+    vscode.window.showErrorMessage(
+      "Failed to copy the snippet to the clipboard"
+    );
+  }
+}
+async function showNotification() {
+  const doNotShowAgain = await vscode.window.showInformationMessage(
+    "The snippet was copied to the clipboard",
+    { modal: false },
+    "Do not show again"
+  );
+
+  if (doNotShowAgain) {
+    const config = vscode.workspace.getConfiguration("snippet");
+    await config.update(
+      "showCopySuccessNotification",
+      false,
+      vscode.ConfigurationTarget.Global
+    );
+  }
+}

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import * as clipboard from "./clipboard";
 import { pickLanguage, getLanguage, getConfig } from "./config";
 import { query } from "./query";
 import { encodeRequest } from "./provider";
@@ -345,31 +346,16 @@ export function copySnippet(treeProvider: SnippetsTreeProvider) {
     }
 
     const content = treeProvider.storage.getSnippet(item.id);
+    await clipboard.copySnippet(content);
+  };
+}
 
-    try {
-      await vscode.env.clipboard.writeText(content);
+export function findAndCopy(snippetsStorage: SnippetsStorage) {
+  return async () => {
+    const language = await getLanguage();
+    const userQuery = await query(language, snippetsStorage, true);
 
-      if (getConfig("showCopySuccessNotification")) {
-        const hideNotification = await vscode.window.showInformationMessage(
-          "The snippet was copied to the clipboard",
-          { modal: false },
-          "Do not show again"
-        );
-
-        if (hideNotification) {
-          const config = vscode.workspace.getConfiguration("snippet");
-          await config.update(
-            "showCopySuccessNotification",
-            false,
-            vscode.ConfigurationTarget.Global
-          );
-        }
-      }
-    } catch {
-      vscode.window.showErrorMessage(
-        "Failed to copy the snippet to the clipboard"
-      );
-    }
+    await clipboard.copySnippet(userQuery.savedSnippetContent);
   };
 }
 

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -335,6 +335,44 @@ export function renameSnippet(treeProvider: SnippetsTreeProvider) {
   };
 }
 
+export function copySnippet(treeProvider: SnippetsTreeProvider) {
+  return async (item: SnippetsTreeItem) => {
+    if (!item) {
+      vscode.window.showInformationMessage(
+        'Copy a snippet right clicking on it in the list and selecting "Copy"'
+      );
+      return;
+    }
+
+    const content = treeProvider.storage.getSnippet(item.id);
+
+    try {
+      await vscode.env.clipboard.writeText(content);
+
+      if (getConfig("showCopySuccessNotification")) {
+        const hideNotification = await vscode.window.showInformationMessage(
+          "The snippet was copied to the clipboard",
+          { modal: false },
+          "Do not show again"
+        );
+
+        if (hideNotification) {
+          const config = vscode.workspace.getConfiguration("snippet");
+          await config.update(
+            "showCopySuccessNotification",
+            false,
+            vscode.ConfigurationTarget.Global
+          );
+        }
+      }
+    } catch {
+      vscode.window.showErrorMessage(
+        "Failed to copy the snippet to the clipboard"
+      );
+    }
+  };
+}
+
 export function createFolder(treeProvider: SnippetsTreeProvider) {
   return async (item?: SnippetsTreeItem) => {
     const opt: vscode.InputBoxOptions = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,6 +60,10 @@ export function activate(ctx: vscode.ExtensionContext) {
     endpoints.renameSnippet(snippetsTreeProvider)
   );
   vscode.commands.registerCommand(
+    "snippet.copySnippet",
+    endpoints.copySnippet(snippetsTreeProvider)
+  );
+  vscode.commands.registerCommand(
     "snippet.createFolder",
     endpoints.createFolder(snippetsTreeProvider)
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,6 +64,10 @@ export function activate(ctx: vscode.ExtensionContext) {
     endpoints.copySnippet(snippetsTreeProvider)
   );
   vscode.commands.registerCommand(
+    "snippet.findAndCopy",
+    endpoints.findAndCopy(snippetsStorage)
+  );
+  vscode.commands.registerCommand(
     "snippet.createFolder",
     endpoints.createFolder(snippetsTreeProvider)
   );

--- a/src/snippetsTreeProvider.ts
+++ b/src/snippetsTreeProvider.ts
@@ -113,6 +113,10 @@ export class SnippetsTreeItem extends vscode.TreeItem {
 
     this.id = id;
     this.tooltip = content;
+    this.contextValue =
+      collapsibleState === vscode.TreeItemCollapsibleState.None
+        ? "snippet"
+        : "folder";
 
     if (collapsibleState !== vscode.TreeItemCollapsibleState.None) {
       return;


### PR DESCRIPTION
This can be useful if a user doesn't want to insert the snippet into the editor immediately but instead wants to copy it and paste into the online editor, for example.