### PR TITLE
Fix invalid snippet insertion when using "Find Inplace"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snippet",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snippet",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@vscode/vsce": "^2.22.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snippet",
   "displayName": "Snippet",
   "description": "Insert a snippet from cht.sh for Python, JavaScript, Ruby, C#, Go, Rust (and any other language)",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "publisher": "vscode-snippet",
   "engines": {
     "vscode": "^1.74.0"

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -62,8 +62,9 @@ export async function findWithProvider(
     });
   } else {
     const text = savedSnippetContent ? savedSnippetContent : doc.getText();
-    const snippet = new vscode.SnippetString(text);
-    const success = await editor.insertSnippet(snippet);
+    const success = await editor.edit((builder) => {
+      builder.insert(editor.selection.start, text);
+    });
     if (!success) {
       vscode.window.showInformationMessage("Error while opening snippet.");
     }


### PR DESCRIPTION
Usage of `vscode.SnippetString` for inserting snippets to the document is resulting in parts of the text of type `${some_text}` being removed (https://code.visualstudio.com/api/references/vscode-api#SnippetString). 

For example, if the user opens .js file, selects "Find inplace" and enters "interpolation string", this line of code:
```js
console.log(`I'm ${age} years old!`)
```
 will become:
 ```js
 console.log(`I'm  years old!`)
 ```

Instead, the snippets should be pasted as-is.

https://github.com/mre/vscode-snippet/assets/79661007/f7e8387a-2964-41c8-80f8-2613e1c2e090

