### PR TITLE
Cleanup dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,15 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: "@types/node"
-    versions:
-    - "> 12.12.11"
-  - dependency-name: "@types/node"
-    versions:
-    - "> 12.12.11, < 12.13"
-  - dependency-name: "@types/vscode"
-    versions:
-    - "> 1.40.0"
-  - dependency-name: "@types/vscode"
-    versions:
-    - "> 1.40.0, < 1.41"
+  - package-ecosystem: npm
+    directory: "/"
+    ignore:
+      - dependency-name: "@types/node"
+        versions:
+          - "> 12.12.11"
+      - dependency-name: "@types/vscode"
+        versions:
+          - "> 1.40.0, < 1.41"
+    groups:
+      - dependencies:
+          patterns:
+            - "*"


### PR DESCRIPTION
- Group dependencies into a single PR. This makes maintenance easier
- Remove redundant package version requirements. (I don't think we need those duplicate entries.)
- Switch to default dependabot schedule.