### PR TITLE
Use `crypto.randomUUID()` for generating random ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snippet",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snippet",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "@vscode/vsce": "^2.22.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "@vscode/vsce": "^2.22.0",
         "axios": "^1.6.2",
         "event-stream": "4.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "nanoid": "^4.0.2"
+        "http-proxy-agent": "^7.0.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",
@@ -23,7 +22,7 @@
         "@rollup/plugin-typescript": "^11.1.5",
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.6",
-        "@types/node": "^12.12.11",
+        "@types/node": "^14.17.0",
         "@types/sinon": "^17.0.2",
         "@types/vscode": "^1.74.0",
         "@typescript-eslint/eslint-plugin": "^5.61.0",
@@ -784,9 +783,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.12.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.11.tgz",
-      "integrity": "sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ==",
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -3532,23 +3531,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
-    "node_modules/nanoid": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18"
-      }
-    },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -5477,9 +5459,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.11.tgz",
-      "integrity": "sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ==",
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
       "dev": true
     },
     "@types/resolve": {
@@ -7459,11 +7441,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
-    },
-    "nanoid": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
     },
     "napi-build-utils": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "axios": "^1.6.2",
         "event-stream": "4.0.1",
         "http-proxy-agent": "^7.0.0",
-        "nanoid": "^3.3.4"
+        "nanoid": "^4.0.2"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",
@@ -3533,14 +3533,20 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^14 || ^16 || >=18"
       }
     },
     "node_modules/napi-build-utils": {
@@ -7455,9 +7461,9 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
     },
     "napi-build-utils": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -260,8 +260,7 @@
     "@vscode/vsce": "^2.22.0",
     "axios": "^1.6.2",
     "event-stream": "4.0.1",
-    "http-proxy-agent": "^7.0.0",
-    "nanoid": "^4.0.2"
+    "http-proxy-agent": "^7.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",
@@ -271,7 +270,7 @@
     "@rollup/plugin-typescript": "^11.1.5",
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.6",
-    "@types/node": "^12.12.11",
+    "@types/node": "^14.17.0",
     "@types/sinon": "^17.0.2",
     "@types/vscode": "^1.74.0",
     "@typescript-eslint/eslint-plugin": "^5.61.0",

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
     "axios": "^1.6.2",
     "event-stream": "4.0.1",
     "http-proxy-agent": "^7.0.0",
-    "nanoid": "^3.3.4"
+    "nanoid": "^4.0.2"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snippet",
   "displayName": "Snippet",
   "description": "Insert a snippet from cht.sh for Python, JavaScript, Ruby, C#, Go, Rust (and any other language)",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "publisher": "vscode-snippet",
   "engines": {
     "vscode": "^1.74.0"

--- a/src/snippetsStorage.ts
+++ b/src/snippetsStorage.ts
@@ -1,4 +1,4 @@
-import { nanoid } from "nanoid";
+import { randomUUID } from "crypto";
 import * as vscode from "vscode";
 
 export interface TreeElement {
@@ -119,7 +119,7 @@ export default class SnippetsStorage {
       : relativeToElement.parentId;
 
     const folder: TreeElementData = {
-      id: nanoid(),
+      id: randomUUID(),
       label: name,
       content: "",
     };
@@ -174,7 +174,7 @@ export default class SnippetsStorage {
     parentId: string
   ): Promise<void> {
     const data: TreeElementData = {
-      id: nanoid(),
+      id: randomUUID(),
       label,
       content,
       fileExtension,
@@ -211,17 +211,17 @@ export default class SnippetsStorage {
 
   private async loadDefaultElements(): Promise<void> {
     const root: TreeElementData = {
-      id: nanoid(),
+      id: randomUUID(),
       label: "root",
       content: "",
     };
     const exampleFolder: TreeElementData = {
-      id: nanoid(),
+      id: randomUUID(),
       label: "example folder",
       content: "",
     };
     const exampleSnippet: TreeElementData = {
-      id: nanoid(),
+      id: randomUUID(),
       label: "example snippet",
       fileExtension: ".js",
       content: `for (let i = 0; i < 5; i++) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "outDir": "out",
         "lib": [
             "es6",
-            "DOM"
+            "DOM",
         ],
         "sourceMap": true,
         "rootDir": "src"


### PR DESCRIPTION
nanoid [removed commonJS support in version 4.0](https://github.com/ai/nanoid/blob/main/CHANGELOG.md#40). I tried to upgrade the library from 3.x to 4.x and encoutered multiple issues related to compatibility between CommonJS and ES modules.

After some research I decided to use built-in [`randomUUID`](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions) function for generating random ids.